### PR TITLE
いろいろレスポンシブにした

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,7 +11,7 @@
 	/* background-color: #e5f0fd; */
 
 
-	padding: 50px 50px;
+	padding: 30px;
 	
 	text-align: center;
 

--- a/src/App.css
+++ b/src/App.css
@@ -16,3 +16,9 @@
 	text-align: center;
 
 }
+
+@media screen and (max-width: 550px) {
+	.app-content-wrapper {
+		min-height: calc(100vh - 70px - 35px); /* Viewport's full size - header - footer */
+	}
+}

--- a/src/comp/Footer.css
+++ b/src/comp/Footer.css
@@ -25,7 +25,7 @@
 
 .footer-row {
 	display: block;
-	width: calc(100vw / 3 - 10px);
+	width: calc(100vw / 3 - 10px - (100vw - 100%) / 3);
 	float: left;
 
 	font-size: 85%;

--- a/src/comp/Footer.css
+++ b/src/comp/Footer.css
@@ -48,3 +48,14 @@
 	padding-left: 15px;
 	margin-bottom: 10px;
 }
+
+@media screen and (max-width: 550px) {
+
+	.footer {
+		height: 35px;
+	}
+
+	.footer-row {
+		display: none;
+	}
+}

--- a/src/comp/Header.css
+++ b/src/comp/Header.css
@@ -8,6 +8,7 @@
 	-khtml-user-select: none;
 	-webkit-user-select: none;
 	user-select: none;
+
 }
 
 .header-logo {
@@ -19,12 +20,12 @@
 	padding: 0 16px;
 
 	color: #eeeeee;
-	
-font-size: 32px;
-	font-weight: bold;
-	
-	text-align: center;
 
+	font-size: 32px;
+	font-weight: bold;
+
+	text-align: center;
+	
 	float: left;
 
 }
@@ -81,13 +82,13 @@ font-size: 32px;
 	color: #333333;
 	
 	float: right;
-	transition: all 0.2s;
 
 }
 
 .header-search-btn:hover {
 	color: #a0c4f4;
 }
+
 
 .header-btn-wrapper {
 
@@ -125,4 +126,29 @@ font-size: 32px;
 .new-regist {
 	font-size: 130%;
 	font-weight: bold;
+}
+
+@media screen and (max-width: 880px) {
+	.header-btn+.resp-low-prio{
+		display: none;
+	}
+}
+
+@media screen and (max-width: 700px) {
+	.header-btn {
+		display: none;
+	}
+}
+
+@media screen and (max-width: 450px) {
+	.header-search-text, .header-search-btn {
+		display: none;
+	}
+
+	.header-logo {
+		box-sizing: border-box;
+		width: 100%;
+		text-align: center;
+	}
+
 }

--- a/src/comp/Header.tsx
+++ b/src/comp/Header.tsx
@@ -38,7 +38,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
 					<div className="header-btn">
 						ログイン
 					</div>
-					<div className="header-btn">
+					<div className="header-btn resp-low-prio">
 						人気プロジェクト
 					</div>
 				</div>

--- a/src/comp/pages/MainPage.css
+++ b/src/comp/pages/MainPage.css
@@ -25,6 +25,9 @@
 	margin-top: 30px;
 }
 
-.button-icon {
-	margin-right: 5px
+@media screen and (max-width: 384px) {
+	.mainpage-button-wrapper {
+		margin: 5px;
+	}
 }
+


### PR DESCRIPTION
端末のサイズによって色々なことが発生します:
# ヘッダー
- `width < 880px` (テキストボックスの幅がキツくなってくる)
  「人気プロジェクト」ボタンが消失します、儚いね
- `width < 700px` (さらにテキストボックスの幅がキツイ)
  ヘッダーのボタンすべてが消え去ります、残酷だね
	あとでハンバーガーメニューとかつけたいお気持ち
- `width < 450px` (さらになおテキストボックスがキツイ)
  テキストボックスが消えてロゴが画面中央に来ます

# フッダー
- `width < 550px` (ここらへんからフッダーに混沌が生まれ始める)
  フッダーのメニューがすべて消失して著作権表示だけになります
	伴ってフッダーが小さくなります

# メインページ
- `width < 384px`
  なんか知らんけどボタンが縦に並んでしまうのでボタン同士の空白を縮めて対処しました

これをすることで close #11 が発生し resolve #12 します